### PR TITLE
Soporte SPM (dual con CocoaPods) — 1.4.1

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -1,0 +1,20 @@
+name: SPM Build & Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  spm:
+    name: swift build & test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Carthage/Build
 # `pod install` in .travis.yml
 #
 # Pods/
+
+# Swift Package Manager
+.build/

--- a/Example/Tests/KhenshinSecureMessageSpec.swift
+++ b/Example/Tests/KhenshinSecureMessageSpec.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 CocoaPods. All rights reserved.
 //
 
+import Foundation
 import Quick
 import Nimble
 import KhenshinSecureMessage

--- a/KhenshinSecureMessage.podspec
+++ b/KhenshinSecureMessage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KhenshinSecureMessage'
-  s.version          = '1.4.0'
+  s.version          = '1.4.1'
   s.summary          = 'KhenshinSecureMessage allows to securely communicate with a Khenshin Server'
   s.description      = <<-DESC
   KhenshinSecureMessage uses NaCl to establish a secure channel that goes on top of a TLS connection.

--- a/KhenshinSecureMessage/Classes/SecureMessage.swift
+++ b/KhenshinSecureMessage/Classes/SecureMessage.swift
@@ -12,8 +12,6 @@ import TweetNacl
 import KHTweetNaclSwift
 #endif
 
-import Foundation
-
 
 public class SecureMessageError : Error
 {

--- a/KhenshinSecureMessage/Classes/SecureMessage.swift
+++ b/KhenshinSecureMessage/Classes/SecureMessage.swift
@@ -6,7 +6,11 @@
 //
 
 import Foundation
+#if SWIFT_PACKAGE
+import TweetNacl
+#else
 import KHTweetNaclSwift
+#endif
 
 import Foundation
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "KhenshinSecureMessage",
+    platforms: [.iOS(.v12), .macOS(.v10_15)],
+    products: [
+        .library(name: "KhenshinSecureMessage", targets: ["KhenshinSecureMessage"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/khipu/tweetnacl-swiftwrap.git", from: "1.1.5"),
+        .package(url: "https://github.com/Quick/Quick.git", "6.0.0"..<"7.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", "11.2.0"..<"13.0.0")
+    ],
+    targets: [
+        .target(
+            name: "KhenshinSecureMessage",
+            dependencies: [.product(name: "TweetNacl", package: "tweetnacl-swiftwrap")],
+            path: "KhenshinSecureMessage/Classes"
+        ),
+        .testTarget(
+            name: "KhenshinSecureMessageTests",
+            dependencies: ["KhenshinSecureMessage", "Quick", "Nimble"],
+            path: "Example/Tests",
+            exclude: ["Info.plist"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Requirements
 
+## Installation (Swift Package Manager)
+
+Add the package to your `Package.swift` dependencies:
+
+    .package(url: "https://github.com/khipu/KhenshinSecureMessage.git", from: "1.4.1")
+
+Then add `KhenshinSecureMessage` to your target's dependencies, or in Xcode use
+**File → Add Package Dependencies…** with the same URL.
+
+> En SPM la criptografía se provee vía `tweetnacl-swiftwrap` (módulo `TweetNacl`);
+> en CocoaPods vía `KHTweetNaclSwift`. La API (`NaclBox`/`NaclSecretBox`) es idéntica
+> y la compatibilidad está cubierta por los tests.
+
 ## Installation
 
 KhenshinSecureMessage is available through [CocoaPods](https://cocoapods.org). To install


### PR DESCRIPTION
Agrega soporte Swift Package Manager en paralelo a CocoaPods.

## Cambios
- `Package.swift` con dependencia a `tweetnacl-swiftwrap` (módulo `TweetNacl`) y `testTarget` con Quick/Nimble.
- Import condicional en `SecureMessage.swift`: `TweetNacl` en SPM, `KHTweetNaclSwift` en CocoaPods. CocoaPods no define `SWIFT_PACKAGE`, así que conserva su comportamiento.
- Bump a **1.4.1**. `spm.yml` (build + test). README con sección SPM.
- Quick capado a 6.x / Nimble a 12.x (Quick 7 cambió `spec()` a método de clase, incompatible con los tests `override func spec()` existentes).

## Validación
`swift build` ✅ · `swift test` 6/6 cripto ✅ (confirma compatibilidad byte-a-byte de tweetnacl-swiftwrap) · `pod lib lint --allow-warnings` ✅ · consumidor SPM round-trip ✅.

Diseño: ver `KhipuClientIOS` `docs/superpowers/specs/2026-06-28-spm-khenshinsecuremessage-design.md`.